### PR TITLE
Fix Read Me - Sub Headings Require 3 Hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Heading Here
 ### Sub-headings
 
 ```
-Sub-Heading Here ##
+Sub-Heading Here ###
 ```
 
 ### Lists


### PR DESCRIPTION
Sub headings were not working for me so I looked at your source and discovered it requires 3 (#) not 2. So I update the readme to reflect that.
